### PR TITLE
Wrapping $user->display_name within sanitize_file_name in a PHP strto…

### DIFF
--- a/init.php
+++ b/init.php
@@ -457,7 +457,7 @@ class basic_user_avatars {
 	 */
 	public function unique_filename_callback( $dir, $name, $ext ) {
 		$user = get_user_by( 'id', (int) $this->user_id_being_edited );
-		$name = $base_name = sanitize_file_name( $user->display_name . '_avatar' );
+		$name = $base_name = sanitize_file_name( strtolower($user->display_name) . '_avatar' );
 		$number = 1;
 
 		while ( file_exists( $dir . "/$name$ext" ) ) {

--- a/init.php
+++ b/init.php
@@ -457,7 +457,8 @@ class basic_user_avatars {
 	 */
 	public function unique_filename_callback( $dir, $name, $ext ) {
 		$user = get_user_by( 'id', (int) $this->user_id_being_edited );
-		$name = $base_name = sanitize_file_name( strtolower($user->display_name) . '_avatar' );
+		$name = $base_name = sanitize_file_name( strtolower( $user->display_name ) . '_avatar' );
+
 		$number = 1;
 
 		while ( file_exists( $dir . "/$name$ext" ) ) {


### PR DESCRIPTION
This plugin fit a need for us. It's simple and gives a quick frontend option to change subscriber avatars on Wordpress. During some testing, we noticed 404's for some of the files the plugin was generating. Using Chrome Dev Tools we noticed the filenames were camel cased; and sometimes in Linux that causes issues depending on how the filesystem is configured. Thus, we tried out wrapping the `$user->display_name` within `sanitize_file_name` in a PHP `strtolower` function and our 404 file issues went away. 