### PR TITLE
Text Domain and Domain Path in plugin header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Welcome to the Basic User Avatars GitHub Repository
 
-This plugin adds an avatar upload field on frontend pages and on the Edit Profile screen so users can add a custom profile picture. =
+This plugin adds an avatar upload field on frontend pages and on the Edit Profile screen so users can add a custom profile picture.
 
 Community and Membership sites on WordPress use this plugin as a lightweight solution for custom user avatars. The plugin is compatible with bbPress, as well as many popular plugins with frontend user registration and profile management features.
 

--- a/init.php
+++ b/init.php
@@ -6,6 +6,8 @@
  * Version:     1.0.6
  * Author:      Stranger Studios
  * Author URI:  https://www.strangerstudios.com/
+ * Text Domain: basic-user-avatars
+ * Domain Path: /languages
  *
  * ---------------------------------------------------------------------------//
  * This plugin is a fork of Simple Local Avatars v1.3.1 by Jake Goldman (10up).


### PR DESCRIPTION
Added this information to the header of the plugin to resolve the GlotPress error.

Fixed a small typo in the README. 