### PR TITLE
fix: :bug: removing action form parameter to submit form to same page

### DIFF
--- a/init.php
+++ b/init.php
@@ -397,7 +397,7 @@ class basic_user_avatars {
 
 		ob_start();
 		?>
-		<form id="basic-user-avatar-form" action="<?php the_permalink(); ?>" method="post" enctype="multipart/form-data">
+		<form id="basic-user-avatar-form" method="post" enctype="multipart/form-data">
 			<?php
 			echo get_avatar( $profileuser->ID );
 


### PR DESCRIPTION
The get_permalink function not always return the current full url. So, it is safer to remove the action parameter and that way, the form will always submit to the current page