### PR TITLE
Bug Fix: Deletes an avatar before we can check duplicates and rename

### DIFF
--- a/init.php
+++ b/init.php
@@ -341,23 +341,7 @@ class basic_user_avatars {
 			if ( ! function_exists( 'wp_handle_upload' ) )
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			/**
-			 * Allow filtering whether to delete existing avatar for user before uploading new avatar.
-			 *
-			 * @since 1.0.7
-			 *
-			 * @param bool $delete_before_upload Whether to delete existing avatar for user before uploading new avatar.
-			 */
-			$delete_before_upload = apply_filters( 'basic_user_avatar_delete_avatar_before_upload', false );
-
-			/*
-			 * Delete old images before handling the upload.
-			 *
-			 * Note: This can cause issues with caching.
-			 */
-			if ( $delete_before_upload ) {
-				$this->avatar_delete( $this->user_id_being_edited );
-			}
+			$this->avatar_delete( $this->user_id_being_edited );
 
 			// Need to be more secure since low privelege users can upload
 			if ( strstr( $_FILES['basic-user-avatar']['name'], '.php' ) )

--- a/init.php
+++ b/init.php
@@ -341,8 +341,10 @@ class basic_user_avatars {
 			if ( ! function_exists( 'wp_handle_upload' ) )
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			// Delete old images if successful
-			$this->avatar_delete( $user_id );
+			// Delete old images if successful - This can cause issues with caching when enabled
+			if( apply_filters( 'basic_user_avatar_delete_avatar_before_upload', false ) ){
+				$this->avatar_delete( $this->user_id_being_edited );
+			}
 
 			// Need to be more secure since low privelege users can upload
 			if ( strstr( $_FILES['basic-user-avatar']['name'], '.php' ) )

--- a/init.php
+++ b/init.php
@@ -349,6 +349,7 @@ class basic_user_avatars {
 			 * @param bool $delete_before_upload Whether to delete existing avatar for user before uploading new avatar.
 			 */
 			$delete_before_upload = apply_filters( 'basic_user_avatar_delete_avatar_before_upload', false );
+
 			/*
 			 * Delete old images before handling the upload.
 			 *

--- a/init.php
+++ b/init.php
@@ -341,8 +341,20 @@ class basic_user_avatars {
 			if ( ! function_exists( 'wp_handle_upload' ) )
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 
-			// Delete old images if successful - This can cause issues with caching when enabled
-			if( apply_filters( 'basic_user_avatar_delete_avatar_before_upload', false ) ){
+			/**
+			 * Allow filtering whether to delete existing avatar for user before uploading new avatar.
+			 *
+			 * @since 1.0.7
+			 *
+			 * @param bool $delete_before_upload Whether to delete existing avatar for user before uploading new avatar.
+			 */
+			$delete_before_upload = apply_filters( 'basic_user_avatar_delete_avatar_before_upload', false );
+			/*
+			 * Delete old images before handling the upload.
+			 *
+			 * Note: This can cause issues with caching.
+			 */
+			if ( $delete_before_upload ) {
 				$this->avatar_delete( $this->user_id_being_edited );
 			}
 


### PR DESCRIPTION
Relates to Issue #43 

We've been deleting the image before we can check if it exists, and then rename it to flush any cache that could be on that image. 

Instead, I've added in a filter called `basic_user_avatar_delete_avatar_before_upload` which is set to false by default. This ensures that if you upload more than one image, we rename it and increment the number (image below)

![image](https://user-images.githubusercontent.com/8989542/146920529-91f1a806-ac83-4884-a26e-45e8932e9d5b.png)


If set to true, it will delete the existing image and upload a file with the exact same file name. Cleaner approach but does cause issues on sites with caching. 