### PR TITLE
Fix PHP 8 deprecation warning.

### DIFF
--- a/init.php
+++ b/init.php
@@ -248,7 +248,7 @@ class basic_user_avatars {
 	 * @param array  $args        Arguments passed to get_avatar_data(), after processing.
 	 * @return string             The filtered avatar HTML.
 	 */
-	public function get_avatar( $avatar, $id_or_email, $size = 96, $default = '', $alt = false, $args ) {
+	public function get_avatar( $avatar, $id_or_email, $size = 96, $default = '', $alt = false, $args = array() ) {
 		/**
 		 * Filter to further customize the avatar HTML.
 		 * 


### PR DESCRIPTION
Having required params after optional params is deprecated in PHP 8: https://www.php.net/manual/en/migration80.deprecated.php. This PR fixes such a deprecation warning.