### PR TITLE
Load text domain from plugins_loaded hook

### DIFF
--- a/init.php
+++ b/init.php
@@ -57,7 +57,7 @@ class basic_user_avatars {
 	public function __construct() {
 
 		// Text domain
-		$this->load_textdomain();
+		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 
 		// Actions
 		add_action( 'admin_init',				 array( $this, 'admin_init'               )        );


### PR DESCRIPTION
Improves loading custom language files, e.g. created by third-party plugins like Loco Translate.