### PR TITLE
Fixes PHP Error

### DIFF
--- a/init.php
+++ b/init.php
@@ -108,9 +108,12 @@ class basic_user_avatars {
 	 */
 	public function avatar_settings_field( $args ) {
 		$options = get_option( 'basic_user_avatars_caps' );
+		
+		$basic_user_avatar_caps = ( $options['basic_user_avatars_caps'] !== false ) ? $options['basic_user_avatar_caps'] : 0;
+
 		?>
 		<label for="basic_user_avatars_caps">
-			<input type="checkbox" name="basic_user_avatars_caps" id="basic_user_avatars_caps" value="1" <?php checked( $options['basic_user_avatars_caps'], 1 ); ?>/>
+			<input type="checkbox" name="basic_user_avatars_caps" id="basic_user_avatars_caps" value="1" <?php checked( $basic_user_avatar_caps, 1 ); ?>/>
 			<?php esc_html_e( 'Only allow users with file upload capabilities to upload local avatars (Authors and above)', 'basic-user-avatars' ); ?>
 		</label>
 		<?php

--- a/init.php
+++ b/init.php
@@ -108,12 +108,12 @@ class basic_user_avatars {
 	 */
 	public function avatar_settings_field( $args ) {
 		$options = get_option( 'basic_user_avatars_caps' );
-		
-		$basic_user_avatar_caps = ( $options['basic_user_avatars_caps'] !== false ) ? $options['basic_user_avatar_caps'] : 0;
+
+		$basic_user_avatars_caps = ! empty( $options['basic_user_avatars_caps'] ) ? 1 : 0;
 
 		?>
 		<label for="basic_user_avatars_caps">
-			<input type="checkbox" name="basic_user_avatars_caps" id="basic_user_avatars_caps" value="1" <?php checked( $basic_user_avatar_caps, 1 ); ?>/>
+			<input type="checkbox" name="basic_user_avatars_caps" id="basic_user_avatars_caps" value="1" <?php checked( $basic_user_avatars_caps, 1 ); ?>/>
 			<?php esc_html_e( 'Only allow users with file upload capabilities to upload local avatars (Authors and above)', 'basic-user-avatars' ); ?>
 		</label>
 		<?php


### PR DESCRIPTION
`PHP Warning: Trying to access array offset on value of type bool in /wp-content/plugins/basic-user-avatars/init.php on line 113`

Error was thrown when the 'Only allow users with file upload capabilities to upload local avatars (Authors and above)' setting was not set or saved on a new/clean installation. 